### PR TITLE
README: Adding README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,0 +1,1 @@
+0.Readme.txt


### PR DESCRIPTION
Adding a README.asciidoc as github renders the
.asciidoc files. README.asciidoc is a soft link
to original  0.Readme.txt.

Signed-off-by: Lalatendu Mohanty lmohanty@redhat.com
